### PR TITLE
Improve .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,6 @@
+.DS_Store
 
 *.xcscheme
-
 *.xcuserstate
-
-AuctionApp.xcodeproj/xcuserdata/Yaron.xcuserdatad/xcschemes/xcschememanagement.plist
-
-Pods/Pods.xcodeproj/xcuserdata/Yaron.xcuserdatad/xcschemes/xcschememanagement.plist
-
-Pods/Pods.xcodeproj/xcuserdata/Amy_Ly.xcuserdatad/xcschemes/xcschememanagement.plist
-
-AuctionApp.xcodeproj/xcuserdata/Amy_Ly.xcuserdatad/
+*.xcscmblueprint
+xcuserdata/


### PR DESCRIPTION
Adds `.DS_Store`,  `xcuserdata/` (for open source contributors), and `*.xcscmblueprint` (for XCode7) to the `.gitignore`.

http://stackoverflow.com/questions/49478/git-ignore-file-for-xcode-projects